### PR TITLE
Update ja.json (translation)

### DIFF
--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -1,6 +1,6 @@
 {
       "title"    : "Node.jsを学んで豊かな人生を！"
-    , "subtitle" : "\u001b[23m問題を選んで \u001b[3mEnter\u001b[23m 押してスタートお願いします："
+    , "subtitle" : "\u001b[23m演習課題を選択、 \u001b[3mEnter\u001b[23m 押してスタートします。"
 	, "exercise" : {
 		"HELLO WORLD": "こんにちは世界"
 	  , "BABY STEPS": "ベイビーステップ"
@@ -17,65 +17,65 @@
 	  , "HTTP JSON API SERVER": "HTTP JSON API サーバ"
 	}
 	, "menu": {
-		"credits": "クレジット"
+		"credits": "謝辞"
 	}
 	, "common": {
 		"exercise": {
 			  "pass": {
-				  "sync": "SYNCの関数が使われています: {{{method}}}"
-				, "async": "ASYNCの関数が使われています: {{{method}}}"
+				  "sync": "同期(syncronus)メソッドが用いられています: {{{method}}}"
+				, "async": "非同期(asyncronus)メソッドが用いられています: {{{method}}}"
 			}
 			, "fail": {
-				  "sync": "SYNCの関数が使われています: {{{method}}}"
-				, "async": "ASYNCの関数が使われています: {{{method}}}"
-				, "unused": "`fs`のモジュールのASYNC関数を使われています"
-				, "unexpected_error": "HTTPサーバがエラーで閉じました: {{{message}}}"
+				  "sync": "同期(syncronus)メソッドが用いられています: {{{method}}}"
+				, "async": "非同期(asyncronus)メソッドが用いられています: {{{method}}}"
+				, "unused": "`fs`モジュールから非同期(asyncronus)メソッドが用いられています"
+				, "unexpected_error": "HTTPサーバから予期せぬエラーが返されました: {{{message}}}"
 			}
 		}
 	}
 	, "exercises": {
 		"MAKE IT MODULAR": {
 			  "fail": {
-				  "missing_module": "Did not use an additional module file, you must require() a module to help solve this exercise"
-				, "loadError": "Error loading module file [{{path}}]: {{{message}}}"
+				  "missing_module": "追加されたモジュールファイルが用いられていません。この演習課題を行うためには、require() が必要です"
+				, "loadError": "モジュールファイル [{{path}}] 読み込み中にエラーが発生しました: {{{message}}}"
 				, "mod": {
-					  "_base": "Your additional module file [{{path}}] {{{message}}}"	
-					, "no_export": "does not export a {{{method}}}. You must use the `module.exports = function () {}` pattern."
+					  "_base": "あなたが追加したモジュールファイル [{{path}}] {{{message}}}"	
+					, "no_export": "{{{method}}} をエクスポートしていません。 `module.exports = function () {}` の形式を用いてください。"
 					, "singleFunction": "single function"
-					, "arguments": "exports a function that takes fewer than {{{three}}} arguments. You must accept a directory, a filter and a {{{callback}}}."
+					, "arguments": "{{{three}}} より少ない引数を受け取る関数をエキスポートしています。ディレクトリ、フィルター、そして {{{callback}}} を受け付けなければいけません。"
 					, "arguments_three": "three"
 					, "arguments_callback": "callback"
-					, "missing_callback": "did not call the callback argument after an error from fs.readdir()"
-					, "missing_error": "does not appear to pass back an error received from `fs.readdir()`.\n  Use the following idiomatic Node.js pattern inside your callback to `fs.readdir()`:\n\tif (err)\n\t  return callback(err)"
-					, "callback_arguments": "did not return two arguments on the callback function (expected `null` and an Array of filenames)"
-					, "array_wrong_size": "did not return an Array with the correct number of elements as the second argument of the callback"
-					, "dotExt": "may be matching \"ext\" instead of \".ext\""
-					, "array_comparison": "did not return the correct list of files as the second argument of the callback"
-					, "missing_array_argument": "did not return an Array object as the second argument of the callback"
-					, "callback_error": "returned an error on its callback:\n\t{{{error}}}"
-					, "timeout": "did not call the callback argument"
-					, "unexpected": "threw an error:\n\t{{{error}}}"
+					, "missing_callback": "fs.readdir() 内でのエラー発生後、コールバック引数を呼んでいません。"
+					, "missing_error": "`fs.readdir()` から受けとったエラーを伝えていないようです。\n あなたの書いたコールバックの中の `fs.readdir()` 呼び出しについて、次の Node.js の慣用的なパターンを用いるようにしてください:\n\tif (err)\n\t  return callback(err)"
+					, "callback_arguments": "コールバック関数に2つの引数を返却していません (`null` とファイル名の配列を期待していました)"
+					, "array_wrong_size": "コールバックの2つめの引数に、正しい要素の数を格納した配列が返却されませんでした"
+					, "dotExt": "\".ext\" ではなく \"ext\" にマッチさせているかもしれません"
+					, "array_comparison": "コールバックの2つめの引数に正しいファイルのリストを返却していません"
+					, "missing_array_argument": "コールバックの2つめの引数に配列オブジェクトを返却していません"
+					, "callback_error": "コールバックでエラーが返却されました:\n\t{{{error}}}"
+					, "timeout": "コールバック引数を呼びませんでした"
+					, "unexpected": "エラーがthrowされました:\n\t{{{error}}}"
 				}
 			}
 			, "pass": {
-				  "singleFunction": "Additional module file exports a single function"
-				, "arguments": "Additional module file exports a function that takes {{{count}}} arguments"
-				, "error": "Additional module file handles errors properly"
-				, "callback": "Additional module file handles callback argument"
-				, "callback_arguments": "Additional module file returned two arguments on the callback function"
-				, "array_argument": "Additional module file returned correct number of elements as the second argument of the callback"
-				, "array_size": "Additional module file returned correct number of elements as the second argument of the callback"
-				, "final": "Additional module file returned correct list of files as the second argument of the callback"
+				  "singleFunction": "追加されたモジュールファイルは、ひとつの関数をエキスポートします。"
+				, "arguments": "追加されたモジュールファイルは、 {{{count}}} 個の引数を受け取る関数をエキスポートします。"
+				, "error": "追加されたモジュールファイルは、エラーを適切に処理します。"
+				, "callback": "追加されたモジュールファイルは、コールバック引数を処理します。"
+				, "callback_arguments": "追加されたモジュールファイルは、コールバックに2つの引数を返却しました。"
+				, "array_argument": "追加されたモジュールファイルは、コールバックの2つめの引数として正しい引数の数を返却しました。"
+				, "array_size": "追加されたモジュールファイルは、コールバックの2つめの引数として正しい引数の数を返却しました。"
+				, "final": "追加されたモジュールファイルは、コールバックの2つめの引数として正しいファイルの一覧を返却しました。"
 			}
 		}
 		, "TIME SERVER": {
 			"fail": {
-				"connection": "Error connecting to localhost:{{port}}: {{{message}}}"
+				"connection": "localhost:{{port}}への接続中にエラーが発生しました: {{{message}}}"
 			}
 		}
 		, "HTTP FILE SERVER": {
 			"fail": {
-				"no_createReadStream": "Used fs method other than fs.createReadStream(): {{{method}}}"
+				"no_createReadStream": "fs.createReadStream()ではない fs メソッドが用いられています : {{{method}}}"
 			}
 		}
 	}


### PR DESCRIPTION
This one was tough.
I tried to keep translated words with a few exception (「クレジット」reminds people "credit cards" to most Japanese,
so changed it to 「謝辞」)

I was not certain that I should translate the followings and left them untouched.
 "arguments_three": "three"
 "arguments_callback": "callback"

 I might have made some mistakes. But the result should not appear as ridiculous or strange.
Please review and change.
